### PR TITLE
Modified KZDV and ZAK entries

### DIFF
--- a/.github/workflows/ZIP.yaml
+++ b/.github/workflows/ZIP.yaml
@@ -48,7 +48,7 @@ jobs:
             args: zip -qq -r KZDC.zip . -i Include/XA/kzdc/* "KZDC Washington ARTCC.isc"
         - uses: montudor/action-zip@v1
           with:
-            args: zip -qq -r KZDV.zip . -i Include/XA/kzdv/* "KZDV Denver 2014.isc"
+            args: zip -qq -r KZDV.zip . -i Include/XA/kzdv/* "KZDV Denver ARTCC.isc"
         - uses: montudor/action-zip@v1
           with:
             args: zip -qq -r KZFW.zip . -i Include/XA/kzfw/* "KZFW Fort Worth ARTCC.isc"
@@ -103,9 +103,6 @@ jobs:
         - uses: montudor/action-zip@v1
           with:
             args: zip -qq -r PHZH.zip . -i Include/XA/phzh/* "PHZH Honolulu ARTCC.isc"
-        - uses: montudor/action-zip@v1
-          with:
-            args: zip -qq -r ZAK.zip . -i Include/XA/kzak/* "ZAK Oakland Oceanic.isc"
         - run: ls -la
         - run: export title="Automatic Release $(date -u +%F_%H:%M:%S)"
         - uses: "marvinpinto/action-automatic-releases@latest"


### PR DESCRIPTION
- Updated KZDV .isc file name to reflect changes to the new sectorfile name.
- Removed ZAK Oakland Oceanic