### PR TITLE
Added Combined Sector Archive to Release Assets

### DIFF
--- a/.github/workflows/ZIP.yaml
+++ b/.github/workflows/ZIP.yaml
@@ -103,6 +103,9 @@ jobs:
         - uses: montudor/action-zip@v1
           with:
             args: zip -qq -r PHZH.zip . -i Include/XA/phzh/* "PHZH Honolulu ARTCC.isc"
+        - uses: montudor/action-zip@v1
+          with:
+            args: zip -qq -r ALL_SECTORS.zip . -i *.zip
         - run: ls -la
         - run: export title="Automatic Release $(date -u +%F_%H:%M:%S)"
         - uses: "marvinpinto/action-automatic-releases@latest"


### PR DESCRIPTION
Every push to main now results in an additional file being created by the action and uploaded to the release named `ALL_SECTORS.zip`. This contains a zip of all zip files in the release as well as any other zip archives in the repository itself.